### PR TITLE
cmake: explicitly link to EDM4hep::edm4hep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ PODIO_ADD_DATAMODEL_CORE_LIB(edm4eic "${headers}" "${sources}"
 # The target for the data model library is defined in podio/cmake/podioMacros.cmake
 # Any changes to that target name upstream may require changes to the target used here 
 target_include_directories(edm4eic PUBLIC ${EDM4HEP_INCLUDE_DIR})
+# It's our responsibility to link to upstream datamodel
+target_link_libraries(edm4eic PRIVATE EDM4HEP::edm4hep)
 
 PODIO_ADD_ROOT_IO_DICT(edm4eicDict edm4eic "${headers}" src/selection.xml
   OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
### Briefly, what does this PR introduce?

https://github.com/AIDASoft/podio/blob/a8efda986f776892e90e7aafa4958aaf18a1e6c7/doc/datamodel_syntax.md?plain=1#L157

Fixes linker errors on macOS:
```
Undefined symbols for architecture x86_64:
  "edm4hep::MCParticle::MCParticle(edm4hep::MCParticleObj*)", referenced from:
      edm4eic::MCRecoParticleAssociation::getSim() const in MCRecoParticleAssociation.cc.o
      edm4eic::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, edm4eic::MCRecoParticleAssociation const&) in MCRecoPart
icleAssociation.cc.o
      edm4eic::MutableMCRecoParticleAssociation::getSim() const in MutableMCRecoParticleAssociation.cc.o
      edm4eic::MCRecoClusterParticleAssociation::getSim() const in MCRecoClusterParticleAssociation.cc.o
      edm4eic::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, edm4eic::MCRecoClusterParticleAssociation const&) in MCR
ecoClusterParticleAssociation.cc.o
      edm4eic::MutableMCRecoClusterParticleAssociation::getSim() const in MutableMCRecoClusterParticleAssociation.cc.o
      edm4eic::MCRecoTrackParticleAssociation::getSim() const in MCRecoTrackParticleAssociation.cc.o
      ...
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

Linking to more libraries should be generally safe. No additional changes are needed.

### Does this PR change default behavior?

No.