### PR TITLE
fix: replace cmake_path with file RELATIVE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,8 @@ install(FILES
 # -------------------------
 # install class documentation
 
-cmake_path(RELATIVE_PATH CMAKE_CURRENT_BINARY_DIR
-  OUTPUT_VARIABLE CMAKE_CURRENT_BINARY_RELATIVE_DIR)
+file(RELATIVE_PATH CMAKE_CURRENT_BINARY_RELATIVE_DIR
+  ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(
   ${CMAKE_SOURCE_DIR}/docs/Doxyfile.in
   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This replaces a call to `cmake_path` (introduced in cmake v3.20) with a more compatible `file` call. `file(RELATIVE_PATH)` exists in [cmake v3.16](https://cmake.org/cmake/help/v3.16/command/file.html) used as minimum for EDM4eic.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #7)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.