### PR TITLE
fix: no need to `target_include_directories`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,6 @@ PODIO_GENERATE_DATAMODEL(edm4eic edm4eic.yaml headers sources
 PODIO_ADD_DATAMODEL_CORE_LIB(edm4eic "${headers}" "${sources}"
   OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
 )
-# The target for the data model library is defined in podio/cmake/podioMacros.cmake
-# Any changes to that target name upstream may require changes to the target used here 
-target_include_directories(edm4eic PUBLIC ${EDM4HEP_INCLUDE_DIR})
 # It's our responsibility to link to upstream datamodel
 target_link_libraries(edm4eic PRIVATE EDM4HEP::edm4hep)
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes the `target_include_directories` introduced in #6 again, since the `target_link_libraries` introduced in #5 set the include directories the right way.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: technical debt reduction

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.