### PR TITLE
docs: build EDM4hep documentation as well

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -865,6 +865,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = README.md \
+                         @EDM4HEP_INCLUDE_DIR@/edm4hep \
                          @CMAKE_CURRENT_BINARY_RELATIVE_DIR@/src \
                          @CMAKE_CURRENT_BINARY_RELATIVE_DIR@/edm4eic \
                          @CMAKE_CURRENT_BINARY_RELATIVE_DIR@/utils


### PR DESCRIPTION
### Briefly, what does this PR introduce?
When we build only EDM4eic documetation at https://eic.github.io/EDM4eic/, we end up with only partial information since all the EDM4hep data types are missing. This adds EDM4hep to the doxygen build.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [X] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.