### PR TITLE
fix: edm4hep needs public linking in edm4eic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ PODIO_ADD_DATAMODEL_CORE_LIB(edm4eic "${headers}" "${sources}"
   OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
 )
 # It's our responsibility to link to upstream datamodel
-target_link_libraries(edm4eic PRIVATE EDM4HEP::edm4hep)
+target_link_libraries(edm4eic PUBLIC EDM4HEP::edm4hep)
 
 PODIO_ADD_ROOT_IO_DICT(edm4eicDict edm4eic "${headers}" src/selection.xml
   OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This will ensure that the public interface of edm4hep is accessible by the public interface of edm4eic, so we can rely on rootcling finding the correct location of e.g. `Vector3f`

### What kind of change does this PR introduce?
- [x] Bug fix (issue: build failure due to rootcling not finding `Vector3f.h`)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.