### PR TITLE
fix: allow setting C++ standard to 17|20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,13 @@ project(EDM4EIC
   VERSION 1.1.0
   LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 20)
+# C++ standard
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "Set the C++ standard to be used")
+if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
+  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 #--- Declare options -----------------------------------------------------------
 option(BUILD_DATA_MODEL "Run podio class generator yaml file" ON)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes #18 and allows setting C++ standard. Should probably be set to whatever ROOT, podio, and EDM4hep are using, and deviations are at the peril of the developer.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #18)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, C++17 is standard.