### PR TITLE
refactor: remove `RawPMTHit` datatype

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -251,16 +251,6 @@ datatypes:
   ## RICH/Cherenkov and PID
   ## ==========================================================================
 
-  edm4eic::RawPMTHit:
-    Description: "EIC Raw PMT hit"
-    Author: "S. Joosten, C. Peng"
-    Members:
-      - uint64_t          cellID            // The detector specific (geometrical) cell id.
-      - uint32_t          integral          // PMT signal integral [ADC]
-      ## @TODO: same question as posed by RawCalorimeterHits, needs revisiting
-      ##        when we increase realism
-      - uint32_t          timeStamp         // PMT signal time [TDC]
-
   edm4eic::PMTHit:
     Description: "EIC PMT hit"
     Author: "S. Joosten, C. Peng"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This datatype is a duplicate of `RawTrackerHit`; any code that needs `RawPMTHit` can just use `RawTrackerHit`.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes; they are addressed by:
- [x] Juggler: https://eicweb.phy.anl.gov/EIC/juggler/-/merge_requests/509
- [x] EICrecon: https://github.com/eic/EICrecon/pull/508
- [x] `RawPMTHit` or its members are not used in any benchmarks

### Does this PR change default behavior?
No