### PR TITLE
feat: add association datatype `MCRecoTrackerHitAssociation`

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright (C) 2022 Sylvester Joosten, Whitney Armstrong, Wouter Deconinck
+# Copyright (C) 2023 Sylvester Joosten, Whitney Armstrong, Wouter Deconinck, Christopher Dilks
 # Some datatypes based on EDM4hep. EDM4hep license applies to those sections.
 ---
 options :
@@ -467,3 +467,13 @@ datatypes:
     OneToOneRelations:
       - edm4eic::Vertex     rec             // reference to the vertex
       - edm4hep::MCParticle sim             // reference to the Monte-Carlo particle
+
+  edm4eic::MCRecoTrackerHitAssociation:
+    Description: "Association between a RawTrackerHit and a SimTrackerHit"
+    Author: "C. Dilks, W. Deconinck"
+    Members:
+      - float                 weight        // weight of this association
+    OneToOneRelations:
+     - edm4eic::RawTrackerHit rawHit        // reference to the digitized hit
+    OneToManyRelations:
+     - edm4hep::SimTrackerHit simHits       // reference to the simulated hits


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add new one-to-many association `datatype` to link digitized tracker hits (`RawTrackerHit`) to the MC-level `SimTrackerHit`s. Close #21.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No