### PR TITLE
add utils/include/edm4eic/unit_system.h

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(edm4eic_utils
 
 install(FILES
   include/edm4eic/analysis_utils.h
+  include/edm4eic/unit_system.h
   include/edm4eic/vector_utils.h
   include/edm4eic/vector_utils_legacy.h
   DESTINATION include/edm4eic

--- a/utils/include/edm4eic/unit_system.h
+++ b/utils/include/edm4eic/unit_system.h
@@ -29,17 +29,17 @@ namespace edm4eic {
     static constexpr double m = 1e3 * mm; // meter
 
     // time
-    static constexpr ns = 1.0; // nano second
-    static constexpr second = 1e9 * ns; // second
-    static constexpr milisecond = 1e6 * ns; // milisecond
-    static constexpr microsecond = 1e3 * ns; // milisecond
-    static constexpr ps = 1e-3 * ns; // pico second
+    static constexpr double ns = 1.0; // nano second
+    static constexpr double second = 1e9 * ns; // second
+    static constexpr double milisecond = 1e6 * ns; // milisecond
+    static constexpr double microsecond = 1e3 * ns; // milisecond
+    static constexpr double ps = 1e-3 * ns; // pico second
 
     // energy
-    static constexpr GeV = 1.0; // giga electron volt
-    static constexpr MeV = 1e-3 * GeV; // mega electron volt
-    static constexpr keV = 1e-6 * GeV; // kilo electron volt
-    static constexpr eV = 1e-9 * GeV; // electron volt
+    static constexpr double GeV = 1.0; // giga electron volt
+    static constexpr double MeV = 1e-3 * GeV; // mega electron volt
+    static constexpr double keV = 1e-6 * GeV; // kilo electron volt
+    static constexpr double eV = 1e-9 * GeV; // electron volt
 
   }
 

--- a/utils/include/edm4eic/unit_system.h
+++ b/utils/include/edm4eic/unit_system.h
@@ -15,18 +15,18 @@ namespace edm4eic {
     // +------------+---------------------|-----------------+
     // | Geant      | TGeo                | EDM4hep/EDM4eic |
     // +------------+---------------------|-----------------+
-    // | milimeter  | centimeter          | centimeter      |
+    // | milimeter  | centimeter          | milimeter       |
     // | nanosecond | second              | nanosecond      |
     // | MeV        | GeV                 | GeV             |
     // +------------+---------------------|-----------------+
     //
 
     // distance
-    static constexpr double cm = 1.0; // centimeter
-    static constexpr double mm = 1e-1 * cm; // millimeter
-    static constexpr double micrometer = 1e-4 * cm; // micrometer
-    static constexpr double nm = 1e-7 * nm; // micrometer
-    static constexpr double m = 1e2 * cm; // meter
+    static constexpr double mm = 1.0; // millimeter
+    static constexpr double cm = 1e1 * mm; // centimeter
+    static constexpr double micrometer = 1e-3 * mm; // micrometer
+    static constexpr double nm = 1e-6 * mm; // micrometer
+    static constexpr double m = 1e3 * mm; // meter
 
     // time
     static constexpr ns = 1.0; // nano second

--- a/utils/include/edm4eic/unit_system.h
+++ b/utils/include/edm4eic/unit_system.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Dmitry Kalinkin
+
+#pragma once
+
+namespace edm4eic {
+
+  namespace unit {
+
+    //
+    // This provides definition for a unique unit system for this EDM. It is
+    // neither Geant, nor TGeo. The DD4hep, by default, uses a system matching
+    // the TGeo one.
+    //
+    // +------------+---------------------|-----------------+
+    // | Geant      | TGeo                | EDM4hep/EDM4eic |
+    // +------------+---------------------|-----------------+
+    // | milimeter  | centimeter          | centimeter      |
+    // | nanosecond | second              | nanosecond      |
+    // | MeV        | GeV                 | GeV             |
+    // +------------+---------------------|-----------------+
+    //
+
+    // distance
+    static constexpr double cm = 1.0; // centimeter
+    static constexpr double mm = 1e-1 * cm; // millimeter
+    static constexpr double micrometer = 1e-4 * cm; // micrometer
+    static constexpr double nm = 1e-7 * nm; // micrometer
+    static constexpr double m = 1e2 * cm; // meter
+
+    // time
+    static constexpr ns = 1.0; // nano second
+    static constexpr second = 1e9 * ns; // second
+    static constexpr milisecond = 1e6 * ns; // milisecond
+    static constexpr microsecond = 1e3 * ns; // milisecond
+    static constexpr ps = 1e-3 * ns; // pico second
+
+    // energy
+    static constexpr GeV = 1.0; // giga electron volt
+    static constexpr MeV = 1e-3 * GeV; // mega electron volt
+    static constexpr keV = 1e-6 * GeV; // mega electron volt
+    static constexpr eV = 1e-9 * GeV; // mega electron volt
+
+  }
+
+}

--- a/utils/include/edm4eic/unit_system.h
+++ b/utils/include/edm4eic/unit_system.h
@@ -24,16 +24,16 @@ namespace edm4eic {
     // distance
     static constexpr double mm = 1.0; // millimeter
     static constexpr double cm = 1e1 * mm; // centimeter
-    static constexpr double micrometer = 1e-3 * mm; // micrometer
-    static constexpr double nm = 1e-6 * mm; // micrometer
+    static constexpr double um = 1e-3 * mm; // micrometer
+    static constexpr double nm = 1e-6 * mm; // nanometer
     static constexpr double m = 1e3 * mm; // meter
 
     // time
-    static constexpr double ns = 1.0; // nano second
-    static constexpr double second = 1e9 * ns; // second
-    static constexpr double milisecond = 1e6 * ns; // milisecond
-    static constexpr double microsecond = 1e3 * ns; // milisecond
-    static constexpr double ps = 1e-3 * ns; // pico second
+    static constexpr double ns = 1.0; // nanosecond
+    static constexpr double s = 1e9 * ns; // second
+    static constexpr double ms = 1e6 * ns; // milisecond
+    static constexpr double us = 1e3 * ns; // microsecond
+    static constexpr double ps = 1e-3 * ns; // picosecond
 
     // energy
     static constexpr double GeV = 1.0; // giga electron volt

--- a/utils/include/edm4eic/unit_system.h
+++ b/utils/include/edm4eic/unit_system.h
@@ -38,8 +38,8 @@ namespace edm4eic {
     // energy
     static constexpr GeV = 1.0; // giga electron volt
     static constexpr MeV = 1e-3 * GeV; // mega electron volt
-    static constexpr keV = 1e-6 * GeV; // mega electron volt
-    static constexpr eV = 1e-9 * GeV; // mega electron volt
+    static constexpr keV = 1e-6 * GeV; // kilo electron volt
+    static constexpr eV = 1e-9 * GeV; // electron volt
 
   }
 


### PR DESCRIPTION
Defines constants to support EDM4hep's unit system to be adopted as the default for EICrecon.