### PR TITLE
build: add package config variable `EDM4EIC_INCLUDE_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ configure_package_config_file(
   cmake/${PROJECT_NAME}Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
   INSTALL_DESTINATION lib/${PROJECT_NAME}
-  PATH_VARS TARGETS_INSTALL_PATH
+  PATH_VARS TARGETS_INSTALL_PATH CMAKE_INSTALL_INCLUDEDIR
   )
 
 write_basic_package_version_file(

--- a/cmake/EDM4EICConfig.cmake.in
+++ b/cmake/EDM4EICConfig.cmake.in
@@ -1,5 +1,5 @@
 @PACKAGE_INIT@
 
 include("@PACKAGE_TARGETS_INSTALL_PATH@")
-
+set_and_check(EDM4EIC_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 check_required_components(EDM4EIC)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This will set `EDM4EIC_INCLUDE_DIR` when `find_package(EDM4EIC)` is called, so users can avoid [figuring it out themselves](https://github.com/eic/EICrecon/blob/a63eff7cd154f756f9bf7faaf5373b4e8571de3e/cmake/jana_plugin.cmake#L226).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no