### PR TITLE
Added Incident angle in data model

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -283,7 +283,7 @@ datatypes:
     VectorMembers:
       - edm4eic::CherenkovParticleIDHypothesis hypotheses         // Evaluated PDG hypotheses
       - edm4hep::Vector2f                      thetaPhiPhotons    // estimated (theta,phi) for each Cherenkov photon
-      - float                                  incidentAngle      // incident photon angle wrt sensor normal
+      - float                                  incidentAngle      // incident MC-truth photon angle wrt sensor normal
     OneToOneRelations:
       - edm4eic::TrackSegment                  chargedParticle    // reconstructed charged particle
     OneToManyRelations:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We wanted to compute the Cherenkov photon impinging angle on the SiPM sensor surface. Therefore, we have added a vector member of float type in the CherenkovPID data model for dRICH.   This is a draft request for @c-dilks to check the changes made at the EICRecon level. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators
@c-dilks and myself discussed about the variable type.

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
