### PR TITLE
39 add surface id member to edm4eictrackpoint

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -140,8 +140,8 @@ components:
       - edm4eic::Cov2f    directionError  // Error on the polar and azimuthal angles
       - float             pathlength      // Pathlength from the origin to this point
       - float             pathlengthError // Error on the pathlength
-      - uint16_t          detectorID      // Detector to which the track point was propagated to
-      - uint16_t          surfaceID       // Surface on which the track point lies (for multiple surfaces per detector)
+      - uint64_t          surface         // Surface track was propagated to (possibly multiple per detector)
+      - uint16_t          system          // Detector system track was propagated to
 
   ## PID hypothesis from Cherenkov detectors
   edm4eic::CherenkovParticleIDHypothesis:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -129,6 +129,8 @@ components:
   ## A point along a track
   edm4eic::TrackPoint:
     Members:
+      - uint64_t          surface         // Surface track was propagated to (possibly multiple per detector)
+      - uint32_t          system          // Detector system track was propagated to
       - edm4hep::Vector3f position        // Position of the trajectory point [mm]
       - edm4eic::Cov3f    positionError   // Error on the position
       - edm4hep::Vector3f momentum        // 3-momentum at the point [GeV]
@@ -140,8 +142,6 @@ components:
       - edm4eic::Cov2f    directionError  // Error on the polar and azimuthal angles
       - float             pathlength      // Pathlength from the origin to this point
       - float             pathlengthError // Error on the pathlength
-      - uint64_t          surface         // Surface track was propagated to (possibly multiple per detector)
-      - uint16_t          system          // Detector system track was propagated to
 
   ## PID hypothesis from Cherenkov detectors
   edm4eic::CherenkovParticleIDHypothesis:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -140,7 +140,8 @@ components:
       - edm4eic::Cov2f    directionError  // Error on the polar and azimuthal angles
       - float             pathlength      // Pathlength from the origin to this point
       - float             pathlengthError // Error on the pathlength
-      - int32_t           surface         // Surface on which the track point lies
+      - uint16_t          detectorID      // Detector to which the track point was propagated to
+      - uint16_t          surfaceID       // Surface on which the track point lies (for multiple surfaces per detector)
 
   ## PID hypothesis from Cherenkov detectors
   edm4eic::CherenkovParticleIDHypothesis:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -140,6 +140,7 @@ components:
       - edm4eic::Cov2f    directionError  // Error on the polar and azimuthal angles
       - float             pathlength      // Pathlength from the origin to this point
       - float             pathlengthError // Error on the pathlength
+      - int32_t           surface         // Surface on which the track point lies
 
   ## PID hypothesis from Cherenkov detectors
   edm4eic::CherenkovParticleIDHypothesis:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds two uint16_t members to TrackPoint to identify the detector and surface on which the TrackPoint lies (implemented for track projections but could be used more generally).

This change replaces the original change which added a single 32-bit integer.  This was done following a discussion in the S&C meeting on August 23, 2023.  Summary of proposed options can be [found here](https://indico.bnl.gov/event/20352/contributions/80021/attachments/49313/84184/followup_edm4eic_trackpoint_PR%20copy.pdf).

### What kind of change does this PR introduce?
- [x] New feature (issue #39)