### PR TITLE
feat: add schema_version

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -5,6 +5,10 @@
 ## Schema versioning
 ## This is required to be an integer, and defined as 100*major+minor.
 ## Patch level changes are required to be schema invariant.
+##
+## If there are schema version changes that can be evolved, see the podio documentation
+## for an example: https://github.com/hegner/podio/blob/master/tests/schema_evolution.yaml
+##
 schema_version: 301
 
 options :

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -2,6 +2,11 @@
 # Copyright (C) 2023 Sylvester Joosten, Whitney Armstrong, Wouter Deconinck, Christopher Dilks
 # Some datatypes based on EDM4hep. EDM4hep license applies to those sections.
 ---
+## Schema versioning
+## This is required to be an integer, and defined as 100*major+minor.
+## Patch level changes are required to be schema invariant.
+schema_version: 301
+
 options :
   # should getters / setters be prefixed with get / set?
   getSyntax: True


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Podio supports schema evolution. This adds the `schema_version` as an integer composed of major and minor version number. No changes have been added that require a schema evolution specification.

Regrettably, this add yet another location where the version number needs to be kept track off, so we now have:
- CMakeLists.txt project version
- edm4eic.yaml schema_version
- tagged release version

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: add schema version)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.