### PR TITLE
feat: Measurement2D to represent 2D surface measurements

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -342,17 +342,16 @@ datatypes:
     Members:
       - uint64_t          surface           // Surface for bound coordinates (geometryID)
       - edm4hep::Vector2f loc               // 2D location on surface
-      - edm4eic::Cov2f    locError          // Covariance on location
       - float             time              // Measurement time
-      - float             timeError         // Error on the time
-      - edm4hep::Vector2f locTimeError      // Covariance on location and time
+      - edm4eic::Cov3f    covariance        // Covariance on location and time
     VectorMembers:
       - float             weights           // Weight for each of the hits, mirrors hits array
-    OneToManyRelations:      
+    OneToManyRelations:
       - edm4eic::TrackerHit hits            // Hits in this measurement (single or clustered)
 
+      
   edm4eic::Trajectory:
-    Description: "Raw trajectory from the tracking algorithm"
+    Description: "Raw trajectory from the tracking algorithm. What is called hit here is 2d measurement indeed."
     Author: "S. Joosten, S. Li"
     Members:
       - uint32_t          type              // 0 (does not have good track fit), 1 (has good track fit)
@@ -368,8 +367,8 @@ datatypes:
       - float             outlierChi2       // Chi2 for each of the outliers
     OneToManyRelations:
       - edm4eic::TrackParameters trackParameters // Associated track parameters, if any
-      - edm4eic::TrackerHit  measurementHits // Measurement hits used in this trajectory
-      - edm4eic::TrackerHit  outlierHits     // Outlier hits not used in this trajectory
+      - edm4eic::Measurement2D  measurementHits // Measurement hits used in this trajectory
+      - edm4eic::Measurement2D  outlierHits     // Outlier hits not used in this trajectory
   
   edm4eic::TrackParameters:
     Description: "ACTS Bound Track parameters"

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -327,6 +327,21 @@ datatypes:
       - float             edep              // Energy deposit in this hit [GeV]
       - float             edepError         // Error on the energy deposit [GeV]
 
+  edm4eic::Measurement2D:
+    Description: "2D measurement (on an arbitrary surface)"
+    Author: "W. Deconinck"
+    Members:
+      - uint64_t          surface           // Surface for bound coordinates (geometryID)
+      - edm4hep::Vector2f loc               // 2D location on surface
+      - edm4eic::Cov2f    locError          // Covariance on location
+      - float             time              // Measurement time
+      - float             timeError         // Error on the time
+      - edm4hep::Vector2f locTimeError      // Covariance on location and time
+    VectorMembers:
+      - float             weights           // Weight for each of the hits, mirrors hits array
+    OneToManyRelations:      
+      - edm4eic::TrackerHit hits            // Hits in this measurement (single or clustered)
+
   edm4eic::Trajectory:
     Description: "Raw trajectory from the tracking algorithm"
     Author: "S. Joosten, S. Li"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds a new datatype, `Measurement2D`, intended primarily but not exclusively for use in Acts track finding. Therefore it tends to mirror what we are already doing. The datatype stores two-dimensional (+time) constraints on a surface with identifier.

`edm4hep::Vector2f locTimeError` is added as a separate field since it is likely to be set to zero often. This makes interactions with the datatype more straightforward than imposing a full 3D `locTime` and 3D triangular covariance matrix.

There is additional motivation and discussion at https://docs.google.com/presentation/d/1ee_iRAyeUao7PwkmFnapX7cASAp4rm8QnQ_moidYDnk/edit, but changes may be applied here without updating the slides.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. Addition of new datatype.

### Does this PR change default behavior?
No.