### PR TITLE
fix: put all operators in vector_utils.h inside namespace

### DIFF
--- a/utils/include/edm4eic/vector_utils.h
+++ b/utils/include/edm4eic/vector_utils.h
@@ -116,7 +116,6 @@ template <Vector3D V> double projection(const V& v, const V& v1) {
   return v * v1 / norm;
 }
 
-} // namespace edm4eic
 template <edm4eic::Vector2D V> V operator+(const V& v1, const V& v2) {
   return {edm4eic::vector_x(v1) + edm4eic::vector_x(v2),
           edm4eic::vector_y(v1) + edm4eic::vector_y(v2)};
@@ -153,5 +152,8 @@ template <edm4eic::VectorND V> V operator-(const V& v1, const V& v2) {
 template <edm4eic::VectorND V> V operator/(const V& v, const double d) {
   return (1. / d) * v;
 }
+
+} // namespace edm4eic
+
 #endif
 #endif


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This puts all operators inside the namespace edm4eic instead of having part of them in, part of them out. Having some out of the namespace affects other headers included after edm4eic/vector_utils.h, e.g.
```
In file included from /home/wdconinc/git/EICrecon/src/algorithms/tracking/TrackProjector.cc:30:
/opt/._local/kabrpic7bxoos4p6tucb5wr2sce6oeio/include/edm4eic/vector_utils.h:153:34: error: overloaded 'operator/' must have at least one parameter of class or enumeration type
  153 | template <edm4eic::VectorND V> V operator/(const V& v, const double d) {
      |                                  ^
/opt/._local/kabrpic7bxoos4p6tucb5wr2sce6oeio/include/fmt/core.h:1483:29: note: in instantiation of function template specialization 'operator/<int>' requested here
 1483 | enum { max_packed_args = 62 / packed_arg_bits };
      |                             ^
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No. I guess you could be relying on these operators being available outside of the edm4eic namespace... but that's off-label use of this product.