### PR TITLE
feat: update vertex edm to 4d quantities

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -438,7 +438,7 @@ datatypes:
       - int32_t             type          // Type flag, to identify what type of vertex it is (e.g. primary, secondary, generated, etc.)
       - float               chi2          // Chi-squared of the vertex fit
       - int                 ndf           // NDF of the vertex fit
-      - edm4hep::Vector4f   position      // [mm] position + time t0 of the vertex. Time is 4th component in vector
+      - edm4hep::Vector4f   position      // position [mm] + time t0 [ns] of the vertex. Time is 4th component in vector
       ## this is named "covMatrix" in EDM4hep, renamed for consistency with the rest of edm4eic
       - edm4eic::Cov4f      positionError // Covariance matrix of the position+time. Time is 4th component, similarly to 4vector 
     OneToManyRelations:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -436,7 +436,7 @@ datatypes:
     Members:
       - int32_t             type       // Type flag, to identify what type of vertex it is (e.g. primary, secondary, generated, etc.)
       - float               chi2          // Chi-squared of the vertex fit
-      - int               ndf   // NDF of the vertex fit
+      - int                 ndf   // NDF of the vertex fit
       - edm4hep::Vector4f   position      // [mm] position + time t0 of the vertex.
       ## this is named "covMatrix" in EDM4hep, renamed for consistency with the rest of edm4eic
       - edm4eic::Cov4f      positionError // Covariance matrix of the position+time 

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -437,7 +437,7 @@ datatypes:
     Members:
       - int32_t             type       // Type flag, to identify what type of vertex it is (e.g. primary, secondary, generated, etc.)
       - float               chi2          // Chi-squared of the vertex fit
-      - int                 ndf   // NDF of the vertex fit
+      - int                 ndf           // NDF of the vertex fit
       - edm4hep::Vector4f   position      // [mm] position + time t0 of the vertex.
       ## this is named "covMatrix" in EDM4hep, renamed for consistency with the rest of edm4eic
       - edm4eic::Cov4f      positionError // Covariance matrix of the position+time 

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -149,7 +149,6 @@ components:
 	  return covariance[i + 1 + (j + 1) * (j) / 2 - 1];\n
 	}\n
       "
- 
   ## A point along a track
   edm4eic::TrackPoint:
     Members:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -149,7 +149,20 @@ components:
 	  return covariance[i + 1 + (j + 1) * (j) / 2 - 1];\n
 	}\n
       "
-
+  edm4eic::Vector4f:
+    Members:
+      - float x
+      - float y
+      - float z
+      - float t
+    ExtraCode:
+      declaration: "
+      constexpr Vector4f() : x(0),y(0),z(0),t(0) {}\n
+      constexpr Vector4f(float xx, float yy, float zz, float tt) : x(xx),y(yy),z(zz),t(tt) {}\n
+      constexpr Vector4f(const float* v) : x(v[0]),y(v[1]),z(v[2]),t(v[3]) {}\n
+      constexpr bool operator==(const Vector4f& v) const { return (x==v.x&&y==v.y&&z==v.z&&t==v.t) ; }\n
+      constexpr float operator[](unsigned i) const { return *( &x + i ) ; }\n
+    "
   ## A point along a track
   edm4eic::TrackPoint:
     Members:
@@ -433,22 +446,16 @@ datatypes:
 
   edm4eic::Vertex:
     Description: "EIC vertex"
-    Author: "W. Armstrong, S. Joosten, based off EDM4hep"
+    Author: "J. Osborn"
     Members:
-      - int32_t             primary       // Boolean flag, if vertex is the primary vertex of the event
+      - int32_t             type       // Type flag, to identify what type of vertex it is (e.g. primary, secondary, generated, etc.)
       - float               chi2          // Chi-squared of the vertex fit
-      - float               probability   // Probability of the vertex fit
-      - edm4hep::Vector3f   position      // [mm] position of the vertex.
+      - int               ndf   // NDF of the vertex fit
+      - edm4eic::Vector4f   position      // [mm] position + time t0 of the vertex.
       ## this is named "covMatrix" in EDM4hep, renamed for consistency with the rest of edm4eic
-      - edm4eic::Cov3f      positionError // Covariance matrix of the position 
-      - int32_t             algorithmType // Type code for the algorithm that has been used to create the vertex - check/set the collection parameters AlgorithmName and AlgorithmType. 
-      ## Additional parameter not in EDM4hep: vertex time
-      - float               time          // Vertex time
-    VectorMembers:
-      - float               parameters    // Additional parameters related to this vertex - check/set the collection parameter "VertexParameterNames" for the parameters meaning. 
-    OneToOneRelations:
-      ## @TODO: why one and not multiple particles?
-      - edm4eic::ReconstructedParticle associatedParticle // reconstructed particle associated to this vertex.
+      - edm4eic::Cov4f      positionError // Covariance matrix of the position+time 
+    OneToManyRelations:
+      - edm4eic::ReconstructedParticle associatedParticles // particles associated to this vertex.
 
   ## ==========================================================================
   ## Kinematic reconstruction

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -149,20 +149,7 @@ components:
 	  return covariance[i + 1 + (j + 1) * (j) / 2 - 1];\n
 	}\n
       "
-  edm4eic::Vector4f:
-    Members:
-      - float x
-      - float y
-      - float z
-      - float t
-    ExtraCode:
-      declaration: "
-      constexpr Vector4f() : x(0),y(0),z(0),t(0) {}\n
-      constexpr Vector4f(float xx, float yy, float zz, float tt) : x(xx),y(yy),z(zz),t(tt) {}\n
-      constexpr Vector4f(const float* v) : x(v[0]),y(v[1]),z(v[2]),t(v[3]) {}\n
-      constexpr bool operator==(const Vector4f& v) const { return (x==v.x&&y==v.y&&z==v.z&&t==v.t) ; }\n
-      constexpr float operator[](unsigned i) const { return *( &x + i ) ; }\n
-    "
+ 
   ## A point along a track
   edm4eic::TrackPoint:
     Members:
@@ -451,7 +438,7 @@ datatypes:
       - int32_t             type       // Type flag, to identify what type of vertex it is (e.g. primary, secondary, generated, etc.)
       - float               chi2          // Chi-squared of the vertex fit
       - int               ndf   // NDF of the vertex fit
-      - edm4eic::Vector4f   position      // [mm] position + time t0 of the vertex.
+      - edm4hep::Vector4f   position      // [mm] position + time t0 of the vertex.
       ## this is named "covMatrix" in EDM4hep, renamed for consistency with the rest of edm4eic
       - edm4eic::Cov4f      positionError // Covariance matrix of the position+time 
     OneToManyRelations:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -435,12 +435,12 @@ datatypes:
     Description: "EIC vertex"
     Author: "J. Osborn"
     Members:
-      - int32_t             type       // Type flag, to identify what type of vertex it is (e.g. primary, secondary, generated, etc.)
+      - int32_t             type          // Type flag, to identify what type of vertex it is (e.g. primary, secondary, generated, etc.)
       - float               chi2          // Chi-squared of the vertex fit
       - int                 ndf           // NDF of the vertex fit
-      - edm4hep::Vector4f   position      // [mm] position + time t0 of the vertex.
+      - edm4hep::Vector4f   position      // [mm] position + time t0 of the vertex. Time is 4th component in vector
       ## this is named "covMatrix" in EDM4hep, renamed for consistency with the rest of edm4eic
-      - edm4eic::Cov4f      positionError // Covariance matrix of the position+time 
+      - edm4eic::Cov4f      positionError // Covariance matrix of the position+time. Time is 4th component, similarly to 4vector 
     OneToManyRelations:
       - edm4eic::ReconstructedParticle associatedParticles // particles associated to this vertex.
 

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -149,6 +149,7 @@ components:
 	  return covariance[i + 1 + (j + 1) * (j) / 2 - 1];\n
 	}\n
       "
+
   ## A point along a track
   edm4eic::TrackPoint:
     Members:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the vertex EDM to contain 4D information, which is going to be needed in our streaming readout environment to separate pile up from physics bunch crossings. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

Discussed in S&C meeting on the 18th of October [here](https://indico.bnl.gov/event/20894/).
### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
It changes the vertex object for which the vertexing algorithm in EICRecon will need to be updated. This should be a simple fix since nothing else depends on the vertexing algorithm at the moment as it is still under development.
