### PR TITLE
fix: Cov6f operator(i,j) must be const

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -142,7 +142,7 @@ components:
       declaration: "
         Cov6f() : covariance{} {}\n
         Cov6f(std::array<float, 21> vcov) : covariance{vcov}{}\n
-	float& operator()(unsigned i, unsigned j) {\n
+	float& operator()(unsigned i, unsigned j) const {\n
 	  if(i > j) {\n
 	    std::swap(i, j);\n
 	    }\n

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -142,12 +142,18 @@ components:
       declaration: "
         Cov6f() : covariance{} {}\n
         Cov6f(std::array<float, 21> vcov) : covariance{vcov}{}\n
-	float& operator()(unsigned i, unsigned j) const {\n
-	  if(i > j) {\n
-	    std::swap(i, j);\n
-	    }\n
-	  return covariance[i + 1 + (j + 1) * (j) / 2 - 1];\n
-	}\n
+        float operator()(unsigned i, unsigned j) const {\n
+          if(i > j) {\n
+            std::swap(i, j);\n
+            }\n
+          return covariance[i + 1 + (j + 1) * (j) / 2 - 1];\n
+        }\n
+        float& operator()(unsigned i, unsigned j) {\n
+          if(i > j) {\n
+            std::swap(i, j);\n
+            }\n
+          return covariance[i + 1 + (j + 1) * (j) / 2 - 1];\n
+        }\n
       "
 
   ## A point along a track


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Without const on this accessor of indexed elements of a covariance, this is not useful since we primarily want to use this on getting and then we only have const collections.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: no const access to covariances)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.