### PR TITLE
Add association between tracker hit and mcparticles

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -544,3 +544,15 @@ datatypes:
      - edm4eic::RawTrackerHit rawHit        // reference to the digitized hit
     OneToManyRelations:
      - edm4hep::SimTrackerHit simHits       // reference to the simulated hits
+
+
+  edm4eic::MCParticleRecoHitAssociation:
+    Description: "Association between a TrackerHit and MCParticles. One tracker hit can be linked to multiple simulation hits hence multiple particles"
+    Author : "S. Li"
+    VectorMembers:
+      - uint32_t            simIDs          // Index of corresponding MCParticles (position in MCParticles array)
+      - float               weights         // weight of this association
+    OneToOneRelations:
+      - edm4eic::TrackerHit trackHit        // reference to the hit
+    OneToManyRelations:
+      - edm4hep::MCParticle mcParticles     // reference to the Monte-Carlo particle

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -549,9 +549,8 @@ datatypes:
   edm4eic::MCParticleRecoHitAssociation:
     Description: "Association between a TrackerHit and MCParticles. One tracker hit can be linked to multiple simulation hits hence multiple particles"
     Author : "S. Li"
-    VectorMembers:
-      - float               weights         // weight of this association
+    Members:
+      - float               weight         // weight of this association
     OneToOneRelations:
       - edm4eic::TrackerHit trackHit        // reference to the hit
-    OneToManyRelations:
-      - edm4hep::MCParticle mcParticles     // reference to the Monte-Carlo particle
+      - edm4hep::MCParticle mcParticle     // reference to the Monte-Carlo particle

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -550,7 +550,6 @@ datatypes:
     Description: "Association between a TrackerHit and MCParticles. One tracker hit can be linked to multiple simulation hits hence multiple particles"
     Author : "S. Li"
     VectorMembers:
-      - uint32_t            simIDs          // Index of corresponding MCParticles (position in MCParticles array)
       - float               weights         // weight of this association
     OneToOneRelations:
       - edm4eic::TrackerHit trackHit        // reference to the hit


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add association between tracker hit and mcparticles to allow easy trace back from hits to mc particles in analysis.  

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No breaking changes.  This is a standalone data structure. Corresponding factory will be developed and inserted to the downstream of tracking algorithm to fill the data structure. It should not interfere with any existing structure.


### Does this PR change default behavior?
No.