### PR TITLE
fix: require edm4hep-0.10.3 (Vector4f in edm4eic::Vertex)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include(GNUInstallDirs)
 find_package(podio 0.15 REQUIRED)
 include_directories(${podio_INCLUDE_DIR})
 
-find_package(EDM4HEP 0.4.1 REQUIRED)
+find_package(EDM4HEP 0.10.3 REQUIRED)
 
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This was overlooked in the #61.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: edm4hep-0.10.2 doesn't work anymore)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
