### PR TITLE
Created data type for hadronic final state variables

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -481,6 +481,16 @@ datatypes:
       ## @TODO: Spin state?
       ## - phi_S?
 
+  edm4eic::HadronicFinalState:
+    Description: "Summed quantities of the hadronic final state"
+    Author: "T. Kutz"
+    Members:
+      - float             sigma             // Longitudinal energy-momentum balance (aka E - pz)
+      - float             pT                // Transverse momentum
+      - float             gamma             // Hadronic angle
+    OneToManyRelations:
+      - edm4eic::ReconstructedParticle hadrons // Reconstructed hadrons used in calculation
+
   ## ==========================================================================
   ## Data-Montecarlo relations
   ## ==========================================================================


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This creates a data type `HadronicFinalState` for variables summed over final state hadrons.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #73 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

New data type, no breaking changes.

### Does this PR change default behavior?

No.