### PR TITLE
Remove TrackerHit "and time" comment

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -352,7 +352,7 @@ datatypes:
       - uint64_t          cellID            // The detector specific (geometrical) cell id.
       - edm4hep::Vector3f position          // Hit (cell) position [mm]
       - edm4eic::CovDiag3f positionError    // Covariance Matrix
-      - float             time              // Hit time
+      - float             time              // Hit time [ns]
       - float             timeError         // Error on the time
       - float             edep              // Energy deposit in this hit [GeV]
       - float             edepError         // Error on the energy deposit [GeV]

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -350,7 +350,7 @@ datatypes:
     Author: "W. Armstrong, S. Joosten"
     Members:
       - uint64_t          cellID            // The detector specific (geometrical) cell id.
-      - edm4hep::Vector3f position          // Hit (cell) position and time [mm, ns]
+      - edm4hep::Vector3f position          // Hit (cell) position [mm]
       - edm4eic::CovDiag3f positionError    // Covariance Matrix
       - float             time              // Hit time
       - float             timeError         // Error on the time


### PR DESCRIPTION
The comment on TrackerHit position which suggests it could/should also be used for time appears to have been left over from a previous version where there was a 4D vector.

https://github.com/eic/EDM4eic/commit/16f26bb0098de3b87172fe43838177662a58a55d