### PR TITLE
feat: new component edm4eic::Surface

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -187,7 +187,7 @@ components:
       - int boundsType                    // eCone = 0, eCylinder = 1, eDiamond = 2, eDisc = 3, eEllipse = 4, eLine = 5, eRectangle = 6, eTrapezoid = 7, eTriangle = 8, eDiscTrapezoid = 9, eConvexPolygon = 10, eAnnulus = 11, eBoundless = 12, eOther = 13
       - uint64_t geometryId               // bit pattern volume:8,boundary:8,layer:12,approach:8,sensitive:20,extra:8
       - uint64_t identifier               // identifier of associated detector element, if available
-      - std::array<double,10> boundValues // bound values, e.g. for RectangleBounds: BoundValues : eMinX = 0, eMinY = 1, eMaxX = 2, eMaxY = 3, eSize = 4
+      - std::array<double,10> boundValues // bound values, e.g. for RectangleBounds, BoundValues are eMinX = 0, eMinY = 1, eMaxX = 2, eMaxY = 3, eSize = 4
       - uint32_t boundValuesSize          // size of bound values
       - std::array<double,16> transform   // row-wise 4x4 affine transform [R T; 0 1] with 3x3 rotation matrix R and translation column 3-vector T
 

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -179,7 +179,18 @@ components:
       - int32_t           PDG             // PDG code
       - float             npe             // Overall photoelectron count
       - float             weight          // Weight of this hypothesis, such as likelihood, moment, etc.
- 
+
+  ## Representation of surfaces, including dynamic perigee surfaces (identical to ActsPodioEdm::Surface)
+  edm4eic::Surface:
+    Members: 
+      - int surfaceType                   // Cone = 0, Cylinder = 1, Disc = 2, Perigee = 3, Plane = 4, Straw = 5, Curvilinear = 6, Other = 7
+      - int boundsType                    // eCone = 0, eCylinder = 1, eDiamond = 2, eDisc = 3, eEllipse = 4, eLine = 5, eRectangle = 6, eTrapezoid = 7, eTriangle = 8, eDiscTrapezoid = 9, eConvexPolygon = 10, eAnnulus = 11, eBoundless = 12, eOther = 13
+      - uint64_t geometryId               // bit pattern volume:8,boundary:8,layer:12,approach:8,sensitive:20,extra:8
+      - uint64_t identifier               // identifier of associated detector element, if available
+      - std::array<double,10> boundValues // bound values, e.g. for RectangleBounds: BoundValues : eMinX = 0, eMinY = 1, eMaxX = 2, eMaxY = 3, eSize = 4
+      - uint32_t boundValuesSize          // size of bound values
+      - std::array<double,16> transform   // row-wise 4x4 affine transform [R T; 0 1] with 3x3 rotation matrix R and translation column 3-vector T
+
 datatypes:
 
   ## ==========================================================================


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a new component to the datamodel, `edm4eic::Surface`, identical to the ActsPodioEdm component. It allows for persistence of arbitrary surfaces, including surfaces that may change from event to event (perigee surfaces) or otherwise are not available in the geometry (effective surfaces with a depth in the calorimeter determined by the reconstructed energy).

The most immediate use is to allow reuse of this component in an Acts::PodioTrackContainer with edm4eic::TrackCollections as the underlying storage backend.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.