### PR TITLE
CMakeLists.txt: extend podio major versions range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif(APPLE)
 
 include(GNUInstallDirs)
 
-find_package(podio 0.15 REQUIRED)
+find_package(podio 0.15...999 REQUIRED)
 include_directories(${podio_INCLUDE_DIR})
 
 find_package(EDM4HEP 0.10.3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,10 @@ endif(APPLE)
 
 include(GNUInstallDirs)
 
-find_package(podio 0.15...999 REQUIRED)
+find_package(podio 0.15)
+if(NOT podio_FOUND)
+  find_package(podio 1.0 REQUIRED)
+endif()
 include_directories(${podio_INCLUDE_DIR})
 
 find_package(EDM4HEP 0.10.3 REQUIRED)


### PR DESCRIPTION
This is to support PODIO v01-00

Fixes:
```
CMake Error at CMakeLists.txt:31 (find_package):
  Could not find a configuration file for package "podio" that is compatible
  with requested version "0.15".

  The following configuration files were considered but not accepted:

    /lib/cmake/podio/podioConfig.cmake, version: 1.0.0
```