### PR TITLE
Add association between raw tracker/calorimeter hit and tracker/calorimeter hit

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -260,7 +260,7 @@ datatypes:
       - int32_t           layer             // Layer that the hit occurred in
       - edm4hep::Vector3f local             // The local coordinates of the hit in the detector segment [mm]. 
     OneToOneRelations:
-      - edm4eic::RawTrackerHit rawCalorimeterHit       // Related raw calorimeter hit
+      - edm4eic::RawCalorimeterHit rawCalorimeterHit       // Related raw calorimeter hit
 
   ## ==========================================================================
   ## Clustering
@@ -370,7 +370,7 @@ datatypes:
       - float             edep              // Energy deposit in this hit [GeV]
       - float             edepError         // Error on the energy deposit [GeV]
     OneToOneRelations:
-      - edm4eic::RawTrackerHit rawHit       // Related raw hit
+      - edm4eic::RawTrackerHit rawTrackerHit       // Related raw tracker hit
       
   edm4eic::Measurement2D:
     Description: "2D measurement (on an arbitrary surface)"
@@ -562,3 +562,12 @@ datatypes:
     OneToOneRelations:
      - edm4eic::RawTrackerHit rawHit        // reference to the digitized hit
      - edm4hep::SimTrackerHit simHit       // reference to the simulated hit
+
+  edm4eic::MCRecoCalorimeterHitAssociation:
+    Description: "Association between a RawCalorimeterHit and a SimCalorimeterHit"
+    Author: "C. Dilks, W. Deconinck"
+    Members:
+      - float                 weight        // weight of this association
+    OneToOneRelations:
+     - edm4eic::RawCalorimeterHit rawCalorimeterHit        // reference to the digitized calorimeter hit
+     - edm4hep::SimCalorimeterHit simCalorimeterHit        // reference to the simulated calorimeter hit

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -565,7 +565,7 @@ datatypes:
 
   edm4eic::MCRecoCalorimeterHitAssociation:
     Description: "Association between a RawCalorimeterHit and a SimCalorimeterHit"
-    Author: "C. Dilks, W. Deconinck"
+    Author: "S. Rahman"
     Members:
       - float                 weight        // weight of this association
     OneToOneRelations:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -260,7 +260,7 @@ datatypes:
       - int32_t           layer             // Layer that the hit occurred in
       - edm4hep::Vector3f local             // The local coordinates of the hit in the detector segment [mm]. 
     OneToOneRelations:
-      - edm4eic::RawCalorimeterHit rawHit   // Related raw calorimeter hit
+      - edm4hep::RawCalorimeterHit rawHit   // Related raw calorimeter hit
 
   ## ==========================================================================
   ## Clustering
@@ -569,5 +569,5 @@ datatypes:
     Members:
       - float                 weight        // weight of this association
     OneToOneRelations:
-     - edm4eic::RawCalorimeterHit rawHit    // reference to the digitized calorimeter hit
+     - edm4hep::RawCalorimeterHit rawHit    // reference to the digitized calorimeter hit
      - edm4hep::SimCalorimeterHit simHit    // reference to the simulated calorimeter hit

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -367,7 +367,6 @@ datatypes:
       - float             timeError         // Error on the time
       - float             edep              // Energy deposit in this hit [GeV]
       - float             edepError         // Error on the energy deposit [GeV]
-      - float             weight            // Weight of association with raw hit
     OneToOneRelations:
       - edm4eic::RawTrackerHit rawHit       // Associated raw hit
       

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -259,6 +259,8 @@ datatypes:
       - int32_t           sector            // Sector that this hit occurred in
       - int32_t           layer             // Layer that the hit occurred in
       - edm4hep::Vector3f local             // The local coordinates of the hit in the detector segment [mm]. 
+    OneToOneRelations:
+      - edm4eic::RawTrackerHit rawCalorimeterHit       // Related raw calorimeter hit
 
   ## ==========================================================================
   ## Clustering
@@ -368,7 +370,7 @@ datatypes:
       - float             edep              // Energy deposit in this hit [GeV]
       - float             edepError         // Error on the energy deposit [GeV]
     OneToOneRelations:
-      - edm4eic::RawTrackerHit rawHit       // Associated raw hit
+      - edm4eic::RawTrackerHit rawHit       // Related raw hit
       
   edm4eic::Measurement2D:
     Description: "2D measurement (on an arbitrary surface)"

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -234,17 +234,6 @@ datatypes:
   ## ==========================================================================
   ## Calorimetry
   ## ==========================================================================
-  edm4eic::RawCalorimeterHit:
-    Description: "Raw (digitized) calorimeter hit"
-    Author: "W. Armstrong, S. Joosten"
-    Members:
-      - uint64_t           cellID            // The detector specific (geometrical) cell id.
-      - uint64_t           amplitude         // The magnitude of the hit in ADC counts.
-        ## @TODO: should we also add integral and time-over-threshold (ToT) here? Or should
-        ##        those all be different raw sensor types? Amplitude is
-        ##        really not what most calorimetry sensors will give us AFAIK...
-      - uint64_t           timeStamp         // Timing in TDC
-
   edm4eic::CalorimeterHit:
     Description: "Calorimeter hit"
     Author: "W. Armstrong, S. Joosten"

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -234,6 +234,17 @@ datatypes:
   ## ==========================================================================
   ## Calorimetry
   ## ==========================================================================
+  edm4eic::RawCalorimeterHit:
+    Description: "Raw (digitized) calorimeter hit"
+    Author: "W. Armstrong, S. Joosten"
+    Members:
+      - uint64_t           cellID            // The detector specific (geometrical) cell id.
+      - uint64_t           amplitude         // The magnitude of the hit in ADC counts.
+        ## @TODO: should we also add integral and time-over-threshold (ToT) here? Or should
+        ##        those all be different raw sensor types? Amplitude is
+        ##        really not what most calorimetry sensors will give us AFAIK...
+      - uint64_t           timeStamp         // Timing in TDC
+
   edm4eic::CalorimeterHit:
     Description: "Calorimeter hit"
     Author: "W. Armstrong, S. Joosten"

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -560,8 +560,8 @@ datatypes:
     Members:
       - float                 weight        // weight of this association
     OneToOneRelations:
-     - edm4eic::RawTrackerHit rawHit        // reference to the digitized hit
-     - edm4hep::SimTrackerHit simHit        // reference to the simulated hit
+      - edm4eic::RawTrackerHit rawHit       // reference to the digitized hit
+      - edm4hep::SimTrackerHit simHit       // reference to the simulated hit
 
   edm4eic::MCRecoCalorimeterHitAssociation:
     Description: "Association between a RawCalorimeterHit and a SimCalorimeterHit"
@@ -569,5 +569,5 @@ datatypes:
     Members:
       - float                 weight        // weight of this association
     OneToOneRelations:
-     - edm4hep::RawCalorimeterHit rawHit    // reference to the digitized calorimeter hit
-     - edm4hep::SimCalorimeterHit simHit    // reference to the simulated calorimeter hit
+      - edm4hep::RawCalorimeterHit rawHit   // reference to the digitized calorimeter hit
+      - edm4hep::SimCalorimeterHit simHit   // reference to the simulated calorimeter hit

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -260,7 +260,7 @@ datatypes:
       - int32_t           layer             // Layer that the hit occurred in
       - edm4hep::Vector3f local             // The local coordinates of the hit in the detector segment [mm]. 
     OneToOneRelations:
-      - edm4eic::RawCalorimeterHit rawCalorimeterHit       // Related raw calorimeter hit
+      - edm4eic::RawCalorimeterHit rawHit       // Related raw calorimeter hit
 
   ## ==========================================================================
   ## Clustering
@@ -370,7 +370,7 @@ datatypes:
       - float             edep              // Energy deposit in this hit [GeV]
       - float             edepError         // Error on the energy deposit [GeV]
     OneToOneRelations:
-      - edm4eic::RawTrackerHit rawTrackerHit       // Related raw tracker hit
+      - edm4eic::RawTrackerHit rawHit       // Related raw tracker hit
       
   edm4eic::Measurement2D:
     Description: "2D measurement (on an arbitrary surface)"
@@ -569,5 +569,5 @@ datatypes:
     Members:
       - float                 weight        // weight of this association
     OneToOneRelations:
-     - edm4eic::RawCalorimeterHit rawCalorimeterHit        // reference to the digitized calorimeter hit
-     - edm4hep::SimCalorimeterHit simCalorimeterHit        // reference to the simulated calorimeter hit
+     - edm4eic::RawCalorimeterHit rawHit        // reference to the digitized calorimeter hit
+     - edm4hep::SimCalorimeterHit simHit        // reference to the simulated calorimeter hit

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -367,7 +367,10 @@ datatypes:
       - float             timeError         // Error on the time
       - float             edep              // Energy deposit in this hit [GeV]
       - float             edepError         // Error on the energy deposit [GeV]
-
+      - float             weight            // Weight of association with raw hit
+    OneToOneRelations:
+      - edm4eic::RawTrackerHit rawHit       // Associated raw hit
+      
   edm4eic::Measurement2D:
     Description: "2D measurement (on an arbitrary surface)"
     Author: "W. Deconinck"

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -260,7 +260,7 @@ datatypes:
       - int32_t           layer             // Layer that the hit occurred in
       - edm4hep::Vector3f local             // The local coordinates of the hit in the detector segment [mm]. 
     OneToOneRelations:
-      - edm4eic::RawCalorimeterHit rawHit       // Related raw calorimeter hit
+      - edm4eic::RawCalorimeterHit rawHit   // Related raw calorimeter hit
 
   ## ==========================================================================
   ## Clustering
@@ -561,7 +561,7 @@ datatypes:
       - float                 weight        // weight of this association
     OneToOneRelations:
      - edm4eic::RawTrackerHit rawHit        // reference to the digitized hit
-     - edm4hep::SimTrackerHit simHit       // reference to the simulated hit
+     - edm4hep::SimTrackerHit simHit        // reference to the simulated hit
 
   edm4eic::MCRecoCalorimeterHitAssociation:
     Description: "Association between a RawCalorimeterHit and a SimCalorimeterHit"
@@ -569,5 +569,5 @@ datatypes:
     Members:
       - float                 weight        // weight of this association
     OneToOneRelations:
-     - edm4eic::RawCalorimeterHit rawHit        // reference to the digitized calorimeter hit
-     - edm4hep::SimCalorimeterHit simHit        // reference to the simulated calorimeter hit
+     - edm4eic::RawCalorimeterHit rawHit    // reference to the digitized calorimeter hit
+     - edm4hep::SimCalorimeterHit simHit    // reference to the simulated calorimeter hit


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add association between raw tracker hit and tracker hit to have full association path from MCParticle to tracker hit. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
