### PR TITLE
Remove redundant edm4eic RawCalorimeterHit type

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -234,17 +234,6 @@ datatypes:
   ## ==========================================================================
   ## Calorimetry
   ## ==========================================================================
-  edm4eic::RawCalorimeterHit:
-    Description: "Raw (digitized) calorimeter hit"
-    Author: "W. Armstrong, S. Joosten"
-    Members:
-      - uint64_t           cellID            // The detector specific (geometrical) cell id.
-      - uint64_t           amplitude         // The magnitude of the hit in ADC counts.
-        ## @TODO: should we also add integral and time-over-threshold (ToT) here? Or should
-        ##        those all be different raw sensor types? Amplitude is
-        ##        really not what most calorimetry sensors will give us AFAIK...
-      - uint64_t           timeStamp         // Timing in TDC
-
   edm4eic::CalorimeterHit:
     Description: "Calorimeter hit"
     Author: "W. Armstrong, S. Joosten"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Remove redundant edm4eic RawCalorimeterHit type. EICrecon uses edm4hep RawCalorimeterHit type everywhere which has signed members instead of unsigned ones here.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
