### PR TITLE
fix: jug_xl -> eic_xl; cvmfs-contrib/github-action-cvmfs@v4; actions/checkout@v4

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -14,11 +14,11 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
-        platform-release: "jug_xl:nightly"
+        platform-release: "eic_xl:nightly"
         run: |
           PREFIX=${PWD}/install
           cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX}
@@ -74,7 +74,7 @@ jobs:
       - /home/runner/work/_temp:/home/runner/work/_temp
       # FIXME hard-coded: see https://github.com/actions/upload-pages-artifact/pull/14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
         name: build-eic-shell


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR replaces instances of jug_xl to eic_xl.