### PR TITLE
Add types for charged/neutral particle candidates

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -207,6 +207,30 @@ datatypes:
   ## Particle info
   ## ==========================================================================
 
+  edm4eic::ChargedRecoParticleCandidate:
+    Description: "Candidate charged reconstructed particle"
+    Author: "Tyler Kutz, Derek Anderson, Shujie Li"
+    OneToOneRelations:
+      - edm4eic::Track      track        // reconstructed track... other relations are matched to this
+    OneToManyRelations:
+      - edm4hep::ParticleID particleIDs  // associated particle IDs
+      - edm4eic::Cluster    ecalClusters // ECAL clusters matched to this track
+      - edm4eic::Cluster    hcalClusters // HCAL clusters matched to this track
+    VectorMembers:
+      - float               ecalWeights  // weights of matched ecal clusters
+      - float               hcalWeights  // weights of matched hcal clusters
+
+  edm4eic::NeutralRecoParticleCandidate:
+    Description: "Candidate neutral reconstructed particle"
+    Author: Tyler Kutz, Derek Anderson, Shujie Li
+    OneToManyRelations:
+      - edm4hep::ParticleID particleIDs  // associated particle IDs
+      - edm4eic::Cluster    ecalClusters // associated ECAL clusters
+      - edm4eic::Cluster    hcalClusters // associated HCAL clusters
+    VectorMembers:
+      - float               ecalWeights  // weights of associated ecal clusters
+      - float               hcalWeights  // weights of associated hcal clusters
+
   edm4eic::ReconstructedParticle:
     Description: "EIC Reconstructed Particle"
     Author: "W. Armstrong, S. Joosten, F. Gaede"


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR introduces the `{Charged,Neutral}RecoParticleCandidate` types. Similar in spirit to the `edm4eic::ProtoCluster`, these types consolidate the necessary track, cluster, and PID relations ahead of any reconstruction of a particle's kinematics and properties.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #97 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

No.