### PR TITLE
Remove irrelevant comment for edm4eic::ReconstructedParticle::PDG

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -232,6 +232,7 @@ datatypes:
     Description: "EIC Reconstructed Particle"
     Author: "W. Armstrong, S. Joosten, F. Gaede"
     Members:
+      - int32_t           PDG               // PDG code for this particle
       - int32_t           type              // type of reconstructed particle. Check/set collection parameters ReconstructedParticleTypeNames and ReconstructedParticleTypeValues.
       - float             energy            // [GeV] energy of the reconstructed particle. Four momentum state is not kept consistent internally.
       - edm4hep::Vector3f momentum          // [GeV] particle momentum. Four momentum state is not kept consistent internally.
@@ -240,14 +241,6 @@ datatypes:
       - float             mass              // [GeV] mass of the reconstructed particle, set independently from four vector. Four momentum state is not kept consistent internally.
       - float             goodnessOfPID     // overall goodness of the PID on a scale of [0;1]
       - edm4eic::Cov4f    covMatrix         // covariance matrix of the reconstructed particle 4vector (10 parameters).
-      ##@TODO: deviation from EDM4hep: store explicit PDG ID here. Needs to be discussed how we
-      ##       move forward as this could easiliy become unwieldy without this information here.
-      ##       The only acceptable alternative would be to store reconstructed identified 
-      ##       particles in separate collections for the different particle types (which would
-      ##       require some algorithmic changes but might work. Doing both might even make
-      ##       sense. Needs some discussion, note that PID is more emphasized in NP than
-      ##       HEP).
-      - int32_t           PDG               // PDG code for this particle
       ## @TODO: Do we need timing info? Or do we rely on the start vertex time?
     OneToOneRelations:
       - edm4eic::Vertex      startVertex    // Start vertex associated to this particle


### PR DESCRIPTION
The PDG field was always there:
https://github.com/key4hep/EDM4hep/blob/f5ee28748cad196b794fd7c84af2d1660dce3684/edm4hep.yaml#L557 There is no deviation, if we don't like the field we should just remove it.