### PR TITLE
Add CALOROC1B data model

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -195,8 +195,8 @@ components:
   edm4eic::CALOROC1ASample:
     Members:
       - uint16_t ADC                // [ADC Counts], amplitude of signal during sample, valid IFF TOTInProgress is false
-      - bool     TOTInProgress      // Flag which indicates if TOT calculation is ongoing, ADC value may be corrupted if this is true
-      - bool     TOTComplete        // Flag which indicates if a TOT calculation is complete and TOT value is valid
+      - uint16_t timeOfArrival      // Time of arrival (TOA) [TDC counts], nonzero IFF ADC crossed threshold upwards during sample
+      - uint16_t timeOverThreshold  // Time over threshold (TOT) [TDC counts], nonzero IFF ADC crossed threshold downwards during sample AND if TOA fired in a previous sample
 
   ## An individual sample output by a CALOROC1B chip
   edm4eic::CALOROC1BSample:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR introduces a data model for the CALOROC1B chip. Although it is not yet available in hardware, it is, together with the HGCROC chip, a strong candidate for the calorimeter readout in the ePIC experiment. Having a dedicated CALOROC1B data model allows us to study its expected performance in detail. The performance not only can be directly compared with the HGCROC-based performance, but also provide useful input for the CALOROC1B chip development.

Since the main difference between the CALOROC1B and HGCROC (CALOROC1A) chip is whether the chip has TOT or low gain ADC, the data model has been implemented based on `edm4eic::HGCROCSample` and `edm4eic::RawHGCROCHit`.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #133)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No