### PR TITLE
datamodel: add edm4eic::AlignmentDerivativeSet for Millepede-II input

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -528,6 +528,18 @@ datatypes:
     VectorMembers:
       - edm4eic::TrackPoint points          // Points where the track parameters were evaluated
 
+  edm4eic::AlignmentDerivativeSet:
+    Description: "Per-surface alignment derivative data for one track, used as input to Millepede-II"
+    Author: "W. Deconinck"
+    Members:
+      - uint64_t  surface              // Acts::GeometryIdentifier of the measurement surface
+      - float     residual             // Measurement residual [mm]
+      - float     residualUncertainty  // Uncertainty on the residual [mm]
+    VectorMembers:
+      - float     localDerivatives   // d(residual)/d(local track params), length = nLocal
+      - int32_t   globalLabels       // Millepede global parameter labels (positive integers)
+      - float     globalDerivatives  // d(residual)/d(alignment DOFs), length = nGlobal
+
   ## ==========================================================================
   ## Vertexing
   ## ==========================================================================

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -532,13 +532,13 @@ datatypes:
     Description: "Per-surface alignment derivative data for one track, used as input to Millepede-II"
     Author: "W. Deconinck"
     Members:
-      - uint64_t  surface              // Acts::GeometryIdentifier of the measurement surface
-      - float     residual             // Measurement residual [mm]
-      - float     residualUncertainty  // Uncertainty on the residual [mm]
+      - uint64_t             surface              // Acts::GeometryIdentifier of the measurement surface
+      - float                residual             // Measurement residual [mm]
+      - float                residualUncertainty  // Uncertainty on the residual [mm]
     VectorMembers:
-      - float     localDerivatives   // d(residual)/d(local track params), length = nLocal
-      - int32_t   globalLabels       // Millepede global parameter labels (positive integers)
-      - float     globalDerivatives  // d(residual)/d(alignment DOFs), length = nGlobal
+      - float                localDerivatives     // d(residual)/d(local track params), length = nLocal
+      - int32_t              globalLabels         // Millepede global parameter labels (positive integers)
+      - float                globalDerivatives    // d(residual)/d(alignment DOFs), length = nGlobal
 
   ## ==========================================================================
   ## Vertexing


### PR DESCRIPTION
## Summary

Adds `edm4eic::AlignmentDerivativeSet`, a new datatype for storing per-surface alignment derivative data produced during track fitting, intended as input to the [Millepede-II](https://www.desy.de/~kleinwrt/MP2/doc/html/index.html) global alignment minimizer.

## Motivation

The ePIC alignment workflow requires a thread-safe mechanism for passing Kalman-filter alignment derivatives from EICrecon (JANA2, multi-threaded) to the Millepede-II `pede` executable. Storing the derivatives in a PODIO collection per event is the natural solution: JANA2 writes one `AlignmentDerivativeSet` per (track, surface) pair, and a separate offline tool converts the collection to the binary Mille format.

## New type

```yaml
edm4eic::AlignmentDerivativeSet:
  Members:
    - uint64_t  surface              # Acts::GeometryIdentifier of the surface
    - float     residual             # track-measurement residual [mm]
    - float     residualUncertainty  # uncertainty on the residual [mm]
  VectorMembers:
    - float     localDerivatives     # d(residual)/d(local track params)
    - int32_t   globalLabels         # Millepede global parameter labels
    - float     globalDerivatives    # d(residual)/d(alignment DOFs)
```

The `int32_t` / `float` ordering of VectorMembers was reviewed: in PODIO's column-oriented storage each VectorMember is an independent heap-allocated `std::vector<T>`, so there is no padding or alignment benefit to reordering them. The order chosen reflects the logical Mille record structure (local params → label/derivative pairs).

## Related PRs

- EICrecon: eic/EICrecon#… (MeasurementToMille algorithm using this type)