### PR TITLE
feat: add momenta() overloads for RC/MC particles; rename momenta_from_tracking

### DIFF
--- a/utils/include/edm4eic/analysis_utils.h
+++ b/utils/include/edm4eic/analysis_utils.h
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 Whitney Armstrong, Sylvester Joosten
-// Copyright (C) 2024 Wouter Deconinck
+// Copyright (C) 2022 - 2024 Whitney Armstrong, Sylvester Joosten, Wouter Deconinck
 
 #ifndef EDM4EIC_UTILS_ANALYSIS_HH
 #define EDM4EIC_UTILS_ANALYSIS_HH

--- a/utils/include/edm4eic/analysis_utils.h
+++ b/utils/include/edm4eic/analysis_utils.h
@@ -12,7 +12,6 @@
 
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
-#include <edm4eic/ReconstructedParticleData.h>
 #include <edm4eic/TrackParametersCollection.h>
 
 namespace edm4eic {

--- a/utils/include/edm4eic/analysis_utils.h
+++ b/utils/include/edm4eic/analysis_utils.h
@@ -1,46 +1,76 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Whitney Armstrong, Sylvester Joosten
+// Copyright (C) 2024 Wouter Deconinck
 
 #ifndef EDM4EIC_UTILS_ANALYSIS_HH
 #define EDM4EIC_UTILS_ANALYSIS_HH
 
 #include <algorithm>
 #include <cmath>
-#include <exception>
-#include <limits>
-#include <string>
 #include <vector>
 
 #include <Math/Vector4D.h>
 
+#include <edm4hep/MCParticleCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
 #include <edm4eic/ReconstructedParticleData.h>
 #include <edm4eic/TrackParametersCollection.h>
 
 namespace edm4eic {
 
-/** Four momentum from track and mass.
- * Get a vector of 4-momenta from raw tracking info, using an externally
- * provided particle mass assumption.
+/** Get a vector of 4-momenta from track parameters, using an externally
+ *  provided mass assumption.
  */
 inline auto
-momenta_from_tracking(const std::vector<edm4eic::TrackParametersData>& tracks,
-                      const double mass) {
-  std::vector<ROOT::Math::PxPyPzMVector> momenta{tracks.size()};
-  // transform our raw tracker info into proper 4-momenta
-  std::transform(tracks.begin(), tracks.end(), momenta.begin(),
+momenta(const std::vector<edm4eic::TrackParametersData>& tracks, const double mass) {
+  std::vector<ROOT::Math::PxPyPzMVector> result{tracks.size()};
+  std::transform(tracks.begin(), tracks.end(), result.begin(),
                  [mass](const auto& track) {
-                   // make sure we don't divide by zero
                    if (fabs(track.qOverP) < 1e-9) {
                      return ROOT::Math::PxPyPzMVector{};
                    }
-                   const double p = fabs(1. / track.qOverP);
+                   const double p  = fabs(1. / track.qOverP);
                    const double px = p * cos(track.phi) * sin(track.theta);
                    const double py = p * sin(track.phi) * sin(track.theta);
                    const double pz = p * cos(track.theta);
                    return ROOT::Math::PxPyPzMVector{px, py, pz, mass};
                  });
-  return momenta;
+  return result;
 }
+
+/** Get a vector of 4-momenta from reconstructed particles.
+ */
+inline auto
+momenta(const std::vector<edm4eic::ReconstructedParticleData>& parts) {
+  std::vector<ROOT::Math::PxPyPzMVector> result{parts.size()};
+  std::transform(parts.begin(), parts.end(), result.begin(),
+                 [](const auto& part) {
+                   return ROOT::Math::PxPyPzMVector{part.momentum.x, part.momentum.y,
+                                                    part.momentum.z, part.mass};
+                 });
+  return result;
+}
+
+/** Get a vector of 4-momenta from Monte Carlo particles.
+ */
+inline auto
+momenta(const std::vector<edm4hep::MCParticleData>& parts) {
+  std::vector<ROOT::Math::PxPyPzMVector> result{parts.size()};
+  std::transform(parts.begin(), parts.end(), result.begin(),
+                 [](const auto& part) {
+                   return ROOT::Math::PxPyPzMVector{part.momentum.x, part.momentum.y,
+                                                    part.momentum.z, part.mass};
+                 });
+  return result;
+}
+
+/** @deprecated Use momenta(tracks, mass) instead. */
+[[deprecated("Use edm4eic::momenta(tracks, mass) instead")]]
+inline auto
+momenta_from_tracking(const std::vector<edm4eic::TrackParametersData>& tracks,
+                      const double mass) {
+  return momenta(tracks, mass);
+}
+
 } // namespace edm4eic
 #endif


### PR DESCRIPTION
## Summary

Add overloaded `edm4eic::momenta()` functions to `analysis_utils.h` covering all three particle data types used in EIC analysis:

| Overload | Input type | Notes |
|----------|-----------|-------|
| `momenta(tracks, mass)` | `TrackParametersData` | Renamed from `momenta_from_tracking` |
| `momenta(parts)` | `ReconstructedParticleData` | Replaces `common_bench::momenta_RC` |
| `momenta(parts)` | `MCParticleData` | Replaces `common_bench::momenta_from_simulation` |

A `[[deprecated]]` fallthrough alias for `momenta_from_tracking` is retained for backward compatibility.

The `momenta_RC` and `momenta_from_simulation` functions in `common_bench/util.h` are verbatim duplicates of this logic and will be removed in companion PR [eic/common_bench#5](https://github.com/eic/common_bench/pull/5).

The active caller (`physics_benchmarks/dvmp/vm_mass.cxx`) is updated in [eic/physics_benchmarks#96](https://github.com/eic/physics_benchmarks/pull/96).

## Changes
- `utils/include/edm4eic/analysis_utils.h`: rename function, add two overloads, deprecated alias, include `edm4hep/MCParticleCollection.h`