### PR TITLE
Split `edm4eic::Cluster::shapeParameters` into individual fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,18 @@ project(EDM4EIC
   LANGUAGES CXX)
 
 SET( ${PROJECT_NAME}_VERSION_MAJOR 8 )
-SET( ${PROJECT_NAME}_VERSION_MINOR 9 )
+SET( ${PROJECT_NAME}_VERSION_MINOR 10 )
 SET( ${PROJECT_NAME}_VERSION_PATCH 0 )
 SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 
 # Verify that schema version in edm4eic.yaml matches project version
-# Schema version is defined as 100*major + 10*minor + patch
+# Schema version is defined as 10000*major + 100*minor + patch
+# (two digits per component, so each component may range from 0 to 99)
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/edm4eic.yaml" EDM4EIC_YAML_CONTENT)
 string(REGEX MATCH "schema_version:[ \t]*([0-9]+)" SCHEMA_VERSION_MATCH "${EDM4EIC_YAML_CONTENT}")
 if(SCHEMA_VERSION_MATCH)
   set(SCHEMA_VERSION ${CMAKE_MATCH_1})
-  math(EXPR EXPECTED_SCHEMA_VERSION "${${PROJECT_NAME}_VERSION_MAJOR} * 100 + ${${PROJECT_NAME}_VERSION_MINOR} * 10 + ${${PROJECT_NAME}_VERSION_PATCH}")
+  math(EXPR EXPECTED_SCHEMA_VERSION "${${PROJECT_NAME}_VERSION_MAJOR} * 10000 + ${${PROJECT_NAME}_VERSION_MINOR} * 100 + ${${PROJECT_NAME}_VERSION_PATCH}")
   if(NOT SCHEMA_VERSION EQUAL EXPECTED_SCHEMA_VERSION)
     message(FATAL_ERROR
       "Schema version mismatch: edm4eic.yaml has schema_version=${SCHEMA_VERSION}, "

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -335,9 +335,8 @@ datatypes:
       - edm4eic::Cov3f    positionError     // Covariance matrix of the position (6 Parameters).
       - float             radius       // Cluster radius [mm].
       - float             dispersion   // Cluster dispersion [mm].
-      - float             widthTheta   // Cluster width in polar (theta) direction [rad].
-      - float             widthPhi     // Cluster width in azimuthal (phi) direction [rad].
-      - std::array<float, 3> principalAxesLengths // Lengths along the cluster's principal axes [mm], sorted in descending order (equivalent to sqrt of eigenvalues of the position covariance, descending).
+      - std::array<float, 3> principalAxesLengthsXYZ      // Lengths along the cluster's principal axes [mm], sorted in descending order (equivalent to sqrt of eigenvalues of the position covariance, descending).
+      - std::array<float, 2> principalAxesLengthsThetaPhi // Lengths along the cluster's principal axes [rad], sorted in descending order.
       - float             intrinsicTheta    // Intrinsic cluster propagation direction polar angle [rad]
       - float             intrinsicPhi      // Intrinsic cluster propagation direction azimuthal angle [rad]
       - edm4eic::Cov2f    intrinsicDirectionError // Error on the intrinsic cluster propagation direction

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -324,7 +324,6 @@ datatypes:
     Description: "EIC hit cluster, reworked to more closely resemble EDM4hep"
     Author: "W. Armstrong, S. Joosten, C.Peng"
     Members:
-      # main variables
       - int32_t           type              // Flag-word that defines the type of the cluster
       - float             energy            // Reconstructed energy of the cluster [GeV].
       - float             energyError       // Error on the cluster energy [GeV]
@@ -333,11 +332,16 @@ datatypes:
       - uint32_t          nhits             // Number of hits in the cluster.
       - edm4hep::Vector3f position          // Global position of the cluster [mm].
       - edm4eic::Cov3f    positionError     // Covariance matrix of the position (6 Parameters).
+      - float             radius       // Cluster radius [mm].
+      - float             dispersion   // Cluster dispersion [mm].
+      - float             widthTheta   // Cluster width in polar (theta) direction [rad].
+      - float             widthPhi     // Cluster width in azimuthal (phi) direction [rad].
+      - std::array<float, 3> principalAxesLengths // Lengths along the cluster's principal axes [mm], sorted in descending order (equivalent to sqrt of eigenvalues of the position covariance, descending).
       - float             intrinsicTheta    // Intrinsic cluster propagation direction polar angle [rad]
       - float             intrinsicPhi      // Intrinsic cluster propagation direction azimuthal angle [rad]
       - edm4eic::Cov2f    intrinsicDirectionError // Error on the intrinsic cluster propagation direction
     VectorMembers:
-      - float             shapeParameters   // Should be set in metadata, for now it's a list of -- radius [mm], dispersion [mm], 2 entries for theta-phi widths [rad], 3 entries for x-y-z widths [mm].
+      - float             shapeParameters   // [DEPRECATED] use radius, dispersion, widthTheta/Phi, and principalAxesLengths instead.
       - float             hitContributions  // Energy contributions of the hits. Runs parallel to ::hits()
       - float             subdetectorEnergies // Energies observed in each subdetector used for this cluster.
     OneToManyRelations:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -341,7 +341,7 @@ datatypes:
       - float             intrinsicPhi      // Intrinsic cluster propagation direction azimuthal angle [rad]. For an XY planar detector one can expect this to be the tilt of "sigma_max" axis.
       - edm4eic::Cov2f    intrinsicDirectionError // Error on the intrinsic cluster propagation direction
     VectorMembers:
-      - float             shapeParameters   // [DEPRECATED] use radius, dispersion, widthTheta/Phi, and principalAxesLengths instead.
+      - float             shapeParameters   // [DEPRECATED] use radius, dispersion, principalAxesLengthsXYZ/ThetaPhi instead.
       - float             hitContributions  // Energy contributions of the hits. Runs parallel to ::hits()
       - float             subdetectorEnergies // Energies observed in each subdetector used for this cluster.
     OneToManyRelations:

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -335,10 +335,10 @@ datatypes:
       - edm4eic::Cov3f    positionError     // Covariance matrix of the position (6 Parameters).
       - float             radius       // Cluster radius [mm].
       - float             dispersion   // Cluster dispersion [mm].
-      - std::array<float, 3> principalAxesLengthsXYZ      // Lengths along the cluster's principal axes [mm], sorted in descending order (equivalent to sqrt of eigenvalues of the position covariance, descending).
+      - std::array<float, 3> principalAxesLengthsXYZ      // Lengths along the cluster's principal axes [mm], sorted in descending order (equivalent to sqrt of eigenvalues of the position covariance). For an XY planar detector one can expect this to be [sigma_max, sigma_min, 0].
       - std::array<float, 2> principalAxesLengthsThetaPhi // Lengths along the cluster's principal axes [rad], sorted in descending order.
-      - float             intrinsicTheta    // Intrinsic cluster propagation direction polar angle [rad]
-      - float             intrinsicPhi      // Intrinsic cluster propagation direction azimuthal angle [rad]
+      - float             intrinsicTheta    // Intrinsic cluster propagation direction polar angle [rad].
+      - float             intrinsicPhi      // Intrinsic cluster propagation direction azimuthal angle [rad]. For an XY planar detector one can expect this to be the tilt of "sigma_max" axis.
       - edm4eic::Cov2f    intrinsicDirectionError // Error on the intrinsic cluster propagation direction
     VectorMembers:
       - float             shapeParameters   // [DEPRECATED] use radius, dispersion, widthTheta/Phi, and principalAxesLengths instead.

--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -3,13 +3,14 @@
 # Some datatypes based on EDM4hep. EDM4hep license applies to those sections.
 ---
 ## Schema versioning
-## This is required to be an integer, and defined as 100*major+10*minor+patch.
+## This is required to be an integer, and defined as 10000*major+100*minor+patch
+## (two digits per component, so each component may range from 0 to 99).
 ## Patch level changes are required to be schema invariant.
 ##
 ## If there are schema version changes that can be evolved, see the podio documentation
 ## for an example: https://github.com/AIDASoft/podio/tree/master/tests/schema_evolution
 ##
-schema_version: 890
+schema_version: 81000
 
 options :
   # should getters / setters be prefixed with get / set?


### PR DESCRIPTION
The current shapeParameters field is to be deprecated.