### PR TITLE
feat: CherenkovParticleID::rawHitAssociations => rawHits

### DIFF
--- a/edm4eic.yaml
+++ b/edm4eic.yaml
@@ -380,7 +380,7 @@ datatypes:
     OneToOneRelations:
       - edm4eic::TrackSegment                  chargedParticle    // reconstructed charged particle
     OneToManyRelations:
-      - edm4eic::MCRecoTrackerHitAssociation   rawHitAssociations // raw sensor hits, associated with MC hits
+      - edm4eic::RawTrackerHit                 rawHits            // raw sensor hits
 
   edm4eic::IrtRadiatorInfo:
     Description: "IRT 2.1 output (radiator level)"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR changes the one-to-many relation CherenkovParticleID::rawHitAssociations to a one-to-many relation to the raw hit. This also works on raw hits only when running without truth, and doesn't affect the running of the algorithm since it only affects output. This is particularly relevant since we are moving away from associations towards links, so having hardcoded requirements for associations is not ideal.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New datatype (issue #__)
- [x] Change to existing datatype (issue: CherenkovParticleID)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [x] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Instead of using CherenkovParticleID::rawHitAssociations, use CherenkovParticleID::rawHits and then map that to sim hits using the optional associations collection.