### PR TITLE
hotfix: remove SIO from CMake since version number too large

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,12 +92,6 @@ add_subdirectory(test)
 
 list(APPEND EDM4EIC_INSTALL_LIBS edm4eic edm4eicDict)
 
-PODIO_ADD_SIO_IO_BLOCKS(edm4eic "${headers}" "${sources}")
-if(TARGET edm4eicSioBlocks)
-  message(STATUS "Building and installing the SioBlocks since podio supports it")
-  list(APPEND EDM4EIC_INSTALL_LIBS edm4eicSioBlocks)
-endif()
-
 if(PODIO_ENABLE_ARROW)
   PODIO_ADD_ARROW(edm4eic "${headers}" "${sources}")
   message(STATUS "Building and installing the Arrow component since podio supports it")


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes the SIO support again since apparently it only supports a short int as version number, and we're using major * 10000 + minor * 100 + patch, which overflows. See https://github.com/AIDASoft/podio/actions/runs/32156321288/job/95774482712?pr=1004. 

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

This currently breaks podio main branch CI workflows.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/AIDASoft/podio/actions/runs/32156321288/job/95774482712?pr=1004)
- [ ] New datatype (issue #__)
- [ ] Change to existing datatype (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
